### PR TITLE
Add support in for optional SSL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,6 +48,9 @@
 # [*repo_key_source*]
 #   Where to source the GPG key from
 #
+# [*ssl*]
+#   Whether a master node should use SSL
+#
 # === Notes
 #
 # * Chances are you are defining hiera in hiera, and as such any variable
@@ -104,6 +107,8 @@ class puppet (
   $repo_repos = 'main dependencies',
   $repo_key = '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
   $repo_key_source = 'https://apt.puppetlabs.com/keyring.gpg',
+  # Master configuration
+  $ssl = true,
 ) {
 
   contain ::puppet::repo

--- a/manifests/master/apache.pp
+++ b/manifests/master/apache.pp
@@ -28,36 +28,49 @@ class puppet::master::apache {
     owner  => 'puppet',
     group  => 'puppet',
     mode   => '0644',
-  } ->
+  }
 
-  apache::vhost { 'puppetmaster':
-    docroot           => '/etc/puppet/rack/public/',
-    port              => '8140',
-    ssl               => true,
-    ssl_protocol      => '-ALL +SSLv3 +TLSv1',
-    ssl_cipher        => 'ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP',
-    ssl_cert          => "${ssldir}/certs/${::fqdn}.pem",
-    ssl_key           => "${ssldir}/private_keys/${::fqdn}.pem",
-    ssl_chain         => "${ssldir}/certs/ca.pem",
-    ssl_ca            => "${ssldir}/certs/ca.pem",
-    ssl_crl_check     => 'chain',
-    ssl_crl           => "${ssldir}/crl.pem",
-    ssl_verify_client => 'optional',
-    ssl_verify_depth  => '1',
-    ssl_options       => '+StdEnvVars +ExportCertData',
-    request_headers   => [
-      'unset X-Forwarded-For',
-      'set X-SSL-Subject %{SSL_CLIENT_S_DN}e',
-      'set X-Client-DN %{SSL_CLIENT_S_DN}e',
-      'set X-Client-Verify %{SSL_CLIENT_VERIFY}e',
-    ],
-    rack_base_uris    => '/',
-    directories       => {
-      path           => '/etc/puppet/rack/public/',
-      options        => 'None',
-      allow_override => 'None',
+  $vhost_params_common = {
+    'docroot'           => '/etc/puppet/rack/public/',
+    'port'              => '8140',
+    'rack_base_uris'    => '/',
+    'directories'       => {
+      'path'           => '/etc/puppet/rack/public/',
+      'options'        => 'None',
+      'allow_override' => 'None',
     },
   }
+
+  if ::puppet::ssl {
+    $vhost_params_ssl = {
+      'ssl'               => true,
+      'ssl_protocol'      => '-ALL +SSLv3 +TLSv1',
+      'ssl_cipher'        => 'ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP',
+      'ssl_cert'          => "${ssldir}/certs/${::fqdn}.pem",
+      'ssl_key'           => "${ssldir}/private_keys/${::fqdn}.pem",
+      'ssl_chain'         => "${ssldir}/certs/ca.pem",
+      'ssl_ca'            => "${ssldir}/certs/ca.pem",
+      'ssl_crl_check'     => 'chain',
+      'ssl_crl'           => "${ssldir}/crl.pem",
+      'ssl_verify_client' => 'optional',
+      'ssl_verify_depth'  => '1',
+      'ssl_options'       => '+StdEnvVars +ExportCertData',
+      'request_headers'   => [
+        'unset X-Forwarded-For',
+        'set X-SSL-Subject %{SSL_CLIENT_S_DN}e',
+        'set X-Client-DN %{SSL_CLIENT_S_DN}e',
+        'set X-Client-Verify %{SSL_CLIENT_VERIFY}e',
+      ],
+    }
+  } else {
+    $vhost_params_ssl = {}
+  }
+
+  $vhost_params = merge($vhost_params_common, $vhost_params_ssl)
+
+  create_resources('apache::vhost', { 'puppetmaster' => {} }, $vhost_params)
+
+  File['/etc/puppet/rack/config.ru'] -> Apache::Vhost['puppetmaster']
 
   # Ensure the master and certificates are installed before starting the server
   Class['::puppet::master'] -> Class['::puppet::master::apache']


### PR DESCRIPTION
Supports the use case where a master is behind a load balancer to
cater for scale out.  It is assumed that the load balancer performs
the necessary SSL verification and trafic to the pool of master workers
is unencrypted
